### PR TITLE
Allow no_std usages.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,9 @@ Suballocators for external memory (e.g., Vulkan device memory)
 keywords = ["allocator", "vulkan", "memory", "suballocator", "tlsf"]
 
 [features]
-default = ["alloc"]
+default = ["std"]
 nightly = []
-alloc = []
+std = []
 
 [dependencies]
 num = ">= 0.2.0, < 0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ keywords = ["allocator", "vulkan", "memory", "suballocator", "tlsf"]
 [features]
 default = ["std"]
 nightly = []
-std = []
+std = ["num/std"]
 
 [dependencies]
-num = ">= 0.2.0, < 0.4.0"
+num = { version = ">= 0.2.0, < 0.4.0", default_features=false}
 unreachable = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,9 @@ Suballocators for external memory (e.g., Vulkan device memory)
 keywords = ["allocator", "vulkan", "memory", "suballocator", "tlsf"]
 
 [features]
+default = ["alloc"]
 nightly = []
+alloc = []
 
 [dependencies]
 num = ">= 0.2.0, < 0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,6 @@ std = ["num/std"]
 hashbrown = [ "dep:hashbrown" ]
 
 [dependencies]
-num = { version = ">= 0.2.0, < 0.4.0", default_features=false}
+num = { version = ">= 0.2.0, < 0.4.0", default_features = false }
 unreachable = "1.0.0"
 hashbrown = { version = "0.12", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,7 @@ keywords = ["allocator", "vulkan", "memory", "suballocator", "tlsf"]
 default = ["std"]
 nightly = []
 std = ["num/std"]
-hashbrown = [ "dep:hashbrown" ]
 
 [dependencies]
 num = { version = ">= 0.2.0, < 0.4.0", default_features = false }
 unreachable = "1.0.0"
-hashbrown = { version = "0.12", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,9 @@ keywords = ["allocator", "vulkan", "memory", "suballocator", "tlsf"]
 default = ["std"]
 nightly = []
 std = ["num/std"]
+hashbrown = [ "dep:hashbrown" ]
 
 [dependencies]
 num = { version = ">= 0.2.0, < 0.4.0", default_features=false}
 unreachable = "1.0.0"
+hashbrown = { version = "0.12", optional = true }

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -11,7 +11,6 @@
 //! [`Tlsf`]: crate::tlsf::Tlsf
 use core::fmt;
 
-
 /// Homogeneous memory arena types supporting operations that do not guarantee
 /// memory safety.
 ///
@@ -201,7 +200,7 @@ pub mod sys {
 pub use self::sys::SysAllocator;
 
 /// Naïve memory-safe implementation of `Arena`.
-#[cfg(feature="alloc")]
+#[cfg(feature = "alloc")]
 pub mod checked {
     use super::*;
     use alloc::collections::BTreeMap;

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -218,9 +218,7 @@ pub use self::sys::SysAllocator;
 /// Naïve memory-safe implementation of `Arena`.
 pub mod checked {
     use super::*;
-    #[cfg(all(not(feature = "std"), feature = "hashbrown"))]
-    use hashbrown::HashMap as MapType;
-    #[cfg(all(not(feature = "std"), not(feature = "hashbrown")))]
+    #[cfg(not(feature = "std"))]
     use alloc::collections::BTreeMap as MapType;
     #[cfg(not(feature = "std"))]
     use alloc::sync::Arc;

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -16,12 +16,6 @@ use std::fmt;
 
 #[cfg(not(feature = "std"))]
 use alloc::boxed::Box;
-#[cfg(not(feature = "std"))]
-use alloc::string::String;
-#[cfg(not(feature = "std"))]
-use alloc::vec;
-#[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
 
 /// Homogeneous memory arena types supporting operations that do not guarantee
 /// memory safety.
@@ -224,7 +218,9 @@ pub use self::sys::SysAllocator;
 /// Naïve memory-safe implementation of `Arena`.
 pub mod checked {
     use super::*;
-    #[cfg(not(feature = "std"))]
+    #[cfg(all(not(feature = "std"), feature = "hashbrown"))]
+    use hashbrown::HashMap as MapType;
+    #[cfg(all(not(feature = "std"), not(feature = "hashbrown")))]
     use alloc::collections::BTreeMap as MapType;
     #[cfg(not(feature = "std"))]
     use alloc::sync::Arc;

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -225,12 +225,12 @@ pub use self::sys::SysAllocator;
 pub mod checked {
     use super::*;
     #[cfg(not(feature = "std"))]
-    use alloc::collections::BTreeMap;
+    use alloc::collections::BTreeMap as MapType;
     #[cfg(not(feature = "std"))]
     use alloc::sync::Arc;
 
     #[cfg(feature = "std")]
-    use std::collections::BTreeMap;
+    use std::collections::HashMap as MapType;
     #[cfg(feature = "std")]
     use std::sync::Arc;
 
@@ -239,7 +239,7 @@ pub mod checked {
     /// For a test purpose only. Do not use this in production. It is really slow.
     #[derive(Debug)]
     pub struct CheckedArena<T> {
-        map: BTreeMap<u64, T>,
+        map: MapType<u64, T>,
         id: Arc<()>,
         next_key: u64,
     }
@@ -252,7 +252,7 @@ pub mod checked {
         /// Construct a `CheckedArena`.
         pub fn new() -> Self {
             Self {
-                map: BTreeMap::new(),
+                map: MapType::new(),
                 id: Arc::new(()),
                 next_key: 0,
             }

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -9,7 +9,19 @@
 //! Memory arena traits (used by [`Tlsf`]).
 //!
 //! [`Tlsf`]: crate::tlsf::Tlsf
+#[cfg(not(feature = "std"))]
 use core::fmt;
+#[cfg(feature = "std")]
+use std::fmt;
+
+#[cfg(not(feature = "std"))]
+use alloc::boxed::Box;
+#[cfg(not(feature = "std"))]
+use alloc::string::String;
+#[cfg(not(feature = "std"))]
+use alloc::vec;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 
 /// Homogeneous memory arena types supporting operations that do not guarantee
 /// memory safety.
@@ -112,9 +124,19 @@ fn test_common<T: UnsafeArenaWithMembershipCheck<&'static str>>(arena: &mut T) {
 /// `UnsafeArena` implementation that relies on the system memory allocator.
 pub mod sys {
     use super::*;
+    #[cfg(not(feature = "std"))]
     use core::mem::{transmute, transmute_copy, ManuallyDrop};
+    #[cfg(not(feature = "std"))]
     use core::ptr::read;
+    #[cfg(not(feature = "std"))]
     use core::ptr::NonNull;
+
+    #[cfg(feature = "std")]
+    use std::mem::{transmute, transmute_copy, ManuallyDrop};
+    #[cfg(feature = "std")]
+    use std::ptr::read;
+    #[cfg(feature = "std")]
+    use std::ptr::NonNull;
 
     /// `UnsafeArena` implementation that relies on the system memory allocator.
     #[derive(Debug, Clone, Copy)]
@@ -200,11 +222,17 @@ pub mod sys {
 pub use self::sys::SysAllocator;
 
 /// Naïve memory-safe implementation of `Arena`.
-#[cfg(feature = "alloc")]
 pub mod checked {
     use super::*;
+    #[cfg(not(feature = "std"))]
     use alloc::collections::BTreeMap;
+    #[cfg(not(feature = "std"))]
     use alloc::sync::Arc;
+
+    #[cfg(feature = "std")]
+    use std::collections::BTreeMap;
+    #[cfg(feature = "std")]
+    use std::sync::Arc;
 
     /// Naïve memory-safe implementation of `Arena`.
     ///
@@ -335,9 +363,19 @@ pub use self::checked::CheckedArena;
 /// Adds a `Vec`-based pool to any memory arena for faster reallocation.
 pub mod pooled {
     use super::*;
+    #[cfg(not(feature = "std"))]
     use core::marker::PhantomData;
+    #[cfg(not(feature = "std"))]
     use core::mem::MaybeUninit;
+    #[cfg(not(feature = "std"))]
     use core::ptr::{drop_in_place, read};
+
+    #[cfg(feature = "std")]
+    use std::marker::PhantomData;
+    #[cfg(feature = "std")]
+    use std::mem::MaybeUninit;
+    #[cfg(feature = "std")]
+    use std::ptr::{drop_in_place, read};
 
     /// Adds a vacant entry pool to any memory arena for faster reallocation.
     #[derive(Debug)]

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -9,13 +9,8 @@
 //! Memory arena traits (used by [`Tlsf`]).
 //!
 //! [`Tlsf`]: crate::tlsf::Tlsf
-#[cfg(not(feature = "std"))]
-use core::fmt;
-#[cfg(feature = "std")]
-use std::fmt;
-
-#[cfg(not(feature = "std"))]
 use alloc::boxed::Box;
+use core::fmt;
 
 /// Homogeneous memory arena types supporting operations that do not guarantee
 /// memory safety.
@@ -118,19 +113,9 @@ fn test_common<T: UnsafeArenaWithMembershipCheck<&'static str>>(arena: &mut T) {
 /// `UnsafeArena` implementation that relies on the system memory allocator.
 pub mod sys {
     use super::*;
-    #[cfg(not(feature = "std"))]
     use core::mem::{transmute, transmute_copy, ManuallyDrop};
-    #[cfg(not(feature = "std"))]
     use core::ptr::read;
-    #[cfg(not(feature = "std"))]
     use core::ptr::NonNull;
-
-    #[cfg(feature = "std")]
-    use std::mem::{transmute, transmute_copy, ManuallyDrop};
-    #[cfg(feature = "std")]
-    use std::ptr::read;
-    #[cfg(feature = "std")]
-    use std::ptr::NonNull;
 
     /// `UnsafeArena` implementation that relies on the system memory allocator.
     #[derive(Debug, Clone, Copy)]
@@ -220,14 +205,10 @@ pub mod checked {
     use super::*;
     #[cfg(not(feature = "std"))]
     use alloc::collections::BTreeMap as MapType;
-    #[cfg(not(feature = "std"))]
     use alloc::sync::Arc;
 
     #[cfg(feature = "std")]
     use std::collections::HashMap as MapType;
-    #[cfg(feature = "std")]
-    use std::sync::Arc;
-
     /// Naïve memory-safe implementation of `Arena`.
     ///
     /// For a test purpose only. Do not use this in production. It is really slow.

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -357,19 +357,9 @@ pub use self::checked::CheckedArena;
 /// Adds a `Vec`-based pool to any memory arena for faster reallocation.
 pub mod pooled {
     use super::*;
-    #[cfg(not(feature = "std"))]
     use core::marker::PhantomData;
-    #[cfg(not(feature = "std"))]
     use core::mem::MaybeUninit;
-    #[cfg(not(feature = "std"))]
     use core::ptr::{drop_in_place, read};
-
-    #[cfg(feature = "std")]
-    use std::marker::PhantomData;
-    #[cfg(feature = "std")]
-    use std::mem::MaybeUninit;
-    #[cfg(feature = "std")]
-    use std::ptr::{drop_in_place, read};
 
     /// Adds a vacant entry pool to any memory arena for faster reallocation.
     #[derive(Debug)]

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -203,12 +203,8 @@ pub use self::sys::SysAllocator;
 /// Naïve memory-safe implementation of `Arena`.
 pub mod checked {
     use super::*;
-    #[cfg(not(feature = "std"))]
     use alloc::collections::BTreeMap as MapType;
     use alloc::sync::Arc;
-
-    #[cfg(feature = "std")]
-    use std::collections::HashMap as MapType;
     /// Naïve memory-safe implementation of `Arena`.
     ///
     /// For a test purpose only. Do not use this in production. It is really slow.

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -9,7 +9,8 @@
 //! Memory arena traits (used by [`Tlsf`]).
 //!
 //! [`Tlsf`]: crate::tlsf::Tlsf
-use std::fmt;
+use core::fmt;
+
 
 /// Homogeneous memory arena types supporting operations that do not guarantee
 /// memory safety.
@@ -112,10 +113,9 @@ fn test_common<T: UnsafeArenaWithMembershipCheck<&'static str>>(arena: &mut T) {
 /// `UnsafeArena` implementation that relies on the system memory allocator.
 pub mod sys {
     use super::*;
-    use std::mem::{transmute, transmute_copy, ManuallyDrop};
-    use std::ptr::read;
-
-    use std::ptr::NonNull;
+    use core::mem::{transmute, transmute_copy, ManuallyDrop};
+    use core::ptr::read;
+    use core::ptr::NonNull;
 
     /// `UnsafeArena` implementation that relies on the system memory allocator.
     #[derive(Debug, Clone, Copy)]
@@ -201,17 +201,18 @@ pub mod sys {
 pub use self::sys::SysAllocator;
 
 /// Naïve memory-safe implementation of `Arena`.
+#[cfg(feature="alloc")]
 pub mod checked {
     use super::*;
-    use std::collections::HashMap;
-    use std::sync::Arc;
+    use alloc::collections::BTreeMap;
+    use alloc::sync::Arc;
 
     /// Naïve memory-safe implementation of `Arena`.
     ///
     /// For a test purpose only. Do not use this in production. It is really slow.
     #[derive(Debug)]
     pub struct CheckedArena<T> {
-        map: HashMap<u64, T>,
+        map: BTreeMap<u64, T>,
         id: Arc<()>,
         next_key: u64,
     }
@@ -224,7 +225,7 @@ pub mod checked {
         /// Construct a `CheckedArena`.
         pub fn new() -> Self {
             Self {
-                map: HashMap::new(),
+                map: BTreeMap::new(),
                 id: Arc::new(()),
                 next_key: 0,
             }
@@ -335,9 +336,9 @@ pub use self::checked::CheckedArena;
 /// Adds a `Vec`-based pool to any memory arena for faster reallocation.
 pub mod pooled {
     use super::*;
-    use std::marker::PhantomData;
-    use std::mem::MaybeUninit;
-    use std::ptr::{drop_in_place, read};
+    use core::marker::PhantomData;
+    use core::mem::MaybeUninit;
+    use core::ptr::{drop_in_place, read};
 
     /// Adds a vacant entry pool to any memory arena for faster reallocation.
     #[derive(Debug)]

--- a/src/bitmap.rs
+++ b/src/bitmap.rs
@@ -41,10 +41,20 @@
 //! ## Performance
 //!
 //! The allocation throughput is roughly the same as of jemalloc.
+#[cfg(not(feature = "std"))]
+use alloc::boxed::Box;
+#[cfg(not(feature = "std"))]
+use alloc::string::String;
+#[cfg(not(feature = "std"))]
+use alloc::vec;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 use bitmaputils::*;
+#[cfg(not(feature = "std"))]
 use core::ops::Range;
 use int::BinaryInteger;
-
+#[cfg(feature = "std")]
+use std::ops::Range;
 /// Free space bitmap-based external memory allocator.
 ///
 /// See [the module-level documentation] for more.

--- a/src/bitmap.rs
+++ b/src/bitmap.rs
@@ -42,8 +42,8 @@
 //!
 //! The allocation throughput is roughly the same as of jemalloc.
 use bitmaputils::*;
-use int::BinaryInteger;
 use core::ops::Range;
+use int::BinaryInteger;
 
 /// Free space bitmap-based external memory allocator.
 ///

--- a/src/bitmap.rs
+++ b/src/bitmap.rs
@@ -41,20 +41,13 @@
 //! ## Performance
 //!
 //! The allocation throughput is roughly the same as of jemalloc.
-#[cfg(not(feature = "std"))]
 use alloc::boxed::Box;
-#[cfg(not(feature = "std"))]
 use alloc::string::String;
-#[cfg(not(feature = "std"))]
 use alloc::vec;
-#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 use bitmaputils::*;
-#[cfg(not(feature = "std"))]
 use core::ops::Range;
 use int::BinaryInteger;
-#[cfg(feature = "std")]
-use std::ops::Range;
 /// Free space bitmap-based external memory allocator.
 ///
 /// See [the module-level documentation] for more.

--- a/src/bitmap.rs
+++ b/src/bitmap.rs
@@ -43,7 +43,7 @@
 //! The allocation throughput is roughly the same as of jemalloc.
 use bitmaputils::*;
 use int::BinaryInteger;
-use std::ops::Range;
+use core::ops::Range;
 
 /// Free space bitmap-based external memory allocator.
 ///

--- a/src/bitmaputils.rs
+++ b/src/bitmaputils.rs
@@ -6,8 +6,8 @@
 // not be copied, modified,or distributed except
 // according to those terms.
 //
-use int::BinaryUInteger;
 use core::ops::Range;
+use int::BinaryUInteger;
 
 pub fn set_bits_ranged<T: BinaryUInteger + Copy>(map: &mut [T], range: Range<usize>) {
     let width = T::max_digits() as usize;

--- a/src/bitmaputils.rs
+++ b/src/bitmaputils.rs
@@ -6,11 +6,8 @@
 // not be copied, modified,or distributed except
 // according to those terms.
 //
-#[cfg(not(feature = "std"))]
 use core::ops::Range;
 use int::BinaryUInteger;
-#[cfg(feature = "std")]
-use std::ops::Range;
 
 pub fn set_bits_ranged<T: BinaryUInteger + Copy>(map: &mut [T], range: Range<usize>) {
     let width = T::max_digits() as usize;

--- a/src/bitmaputils.rs
+++ b/src/bitmaputils.rs
@@ -6,8 +6,11 @@
 // not be copied, modified,or distributed except
 // according to those terms.
 //
+#[cfg(not(feature = "std"))]
 use core::ops::Range;
 use int::BinaryUInteger;
+#[cfg(feature = "std")]
+use std::ops::Range;
 
 pub fn set_bits_ranged<T: BinaryUInteger + Copy>(map: &mut [T], range: Range<usize>) {
     let width = T::max_digits() as usize;
@@ -319,7 +322,10 @@ mod find_zeros_tests {
 
     struct BitField<'a, T: 'a>(&'a [T]);
 
+    #[cfg(not(feature = "std"))]
     use core::fmt;
+    #[cfg(feature = "std")]
+    use std::fmt;
     impl<'a, T: BinaryUInteger + Copy + 'a> fmt::Debug for BitField<'a, T> {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             write!(f, "BitField (")?;

--- a/src/bitmaputils.rs
+++ b/src/bitmaputils.rs
@@ -322,10 +322,7 @@ mod find_zeros_tests {
 
     struct BitField<'a, T: 'a>(&'a [T]);
 
-    #[cfg(not(feature = "std"))]
     use core::fmt;
-    #[cfg(feature = "std")]
-    use std::fmt;
     impl<'a, T: BinaryUInteger + Copy + 'a> fmt::Debug for BitField<'a, T> {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             write!(f, "BitField (")?;

--- a/src/bitmaputils.rs
+++ b/src/bitmaputils.rs
@@ -7,7 +7,7 @@
 // according to those terms.
 //
 use int::BinaryUInteger;
-use std::ops::Range;
+use core::ops::Range;
 
 pub fn set_bits_ranged<T: BinaryUInteger + Copy>(map: &mut [T], range: Range<usize>) {
     let width = T::max_digits() as usize;
@@ -319,7 +319,7 @@ mod find_zeros_tests {
 
     struct BitField<'a, T: 'a>(&'a [T]);
 
-    use std::fmt;
+    use core::fmt;
     impl<'a, T: BinaryUInteger + Copy + 'a> fmt::Debug for BitField<'a, T> {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             write!(f, "BitField (")?;

--- a/src/int.rs
+++ b/src/int.rs
@@ -8,8 +8,8 @@
 //
 //! Traits for integral types.
 use num::Integer;
-use std::mem::size_of;
-use std::{fmt, ops};
+use core::mem::size_of;
+use core::{fmt, ops};
 
 /// Integral types with efficient binary operations.
 pub trait BinaryInteger:

--- a/src/int.rs
+++ b/src/int.rs
@@ -7,8 +7,15 @@
 // according to those terms.
 //
 //! Traits for integral types.
+#[cfg(not(feature = "std"))]
 use core::mem::size_of;
+#[cfg(not(feature = "std"))]
 use core::{fmt, ops};
+#[cfg(feature = "std")]
+use std::mem::size_of;
+#[cfg(feature = "std")]
+use std::{fmt, ops};
+
 use num::Integer;
 
 /// Integral types with efficient binary operations.

--- a/src/int.rs
+++ b/src/int.rs
@@ -7,9 +7,9 @@
 // according to those terms.
 //
 //! Traits for integral types.
-use num::Integer;
 use core::mem::size_of;
 use core::{fmt, ops};
+use num::Integer;
 
 /// Integral types with efficient binary operations.
 pub trait BinaryInteger:

--- a/src/int.rs
+++ b/src/int.rs
@@ -7,14 +7,8 @@
 // according to those terms.
 //
 //! Traits for integral types.
-#[cfg(not(feature = "std"))]
 use core::mem::size_of;
-#[cfg(not(feature = "std"))]
 use core::{fmt, ops};
-#[cfg(feature = "std")]
-use std::mem::size_of;
-#[cfg(feature = "std")]
-use std::{fmt, ops};
 
 use num::Integer;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,8 @@
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 pub extern crate num;
+#[cfg(feature = "hashbrown")]
+pub extern crate hashbrown;
 extern crate unreachable;
 
 pub mod arena;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,9 @@
 // Clippy does not understand that generic numeric types are not always
 // as capable as built-in ones and raise false warnings
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::op_ref))]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
+#[cfg(feature = "std")]
+extern crate std;
 
 extern crate alloc;
 pub extern crate num;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,24 +59,24 @@
 // as capable as built-in ones and raise false warnings
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::op_ref))]
 
+#[cfg(feature = "alloc")]
+extern crate alloc;
+extern crate core;
 pub extern crate num;
 extern crate unreachable;
-extern crate core;
-#[cfg(feature="alloc")]
-extern crate alloc;
 
-#[cfg(feature="alloc")]
+#[cfg(feature = "alloc")]
 pub mod arena;
 pub mod bitmap;
 mod bitmaputils;
 pub mod int;
 pub mod ring;
-#[cfg(feature="alloc")]
+#[cfg(feature = "alloc")]
 pub mod tlsf;
 
 pub use self::bitmap::{BitmapAlloc, BitmapAllocRegion};
 pub use self::ring::{Ring, RingRegion};
-#[cfg(feature="alloc")]
+#[cfg(feature = "alloc")]
 pub use self::tlsf::{
     SafeTlsf, SafeTlsfRegion, SysTlsf, SysTlsfRegion, Tlsf, TlsfBlock, TlsfRegion,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,25 +58,23 @@
 // Clippy does not understand that generic numeric types are not always
 // as capable as built-in ones and raise false warnings
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::op_ref))]
+#![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(feature = "alloc")]
+#[cfg(not(feature = "std"))]
 extern crate alloc;
-extern crate core;
 pub extern crate num;
 extern crate unreachable;
 
-#[cfg(feature = "alloc")]
 pub mod arena;
 pub mod bitmap;
 mod bitmaputils;
 pub mod int;
 pub mod ring;
-#[cfg(feature = "alloc")]
 pub mod tlsf;
 
 pub use self::bitmap::{BitmapAlloc, BitmapAllocRegion};
 pub use self::ring::{Ring, RingRegion};
-#[cfg(feature = "alloc")]
+
 pub use self::tlsf::{
     SafeTlsf, SafeTlsfRegion, SysTlsf, SysTlsfRegion, Tlsf, TlsfBlock, TlsfRegion,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,7 @@
 //! - `nightly` — Enables optimizations which currently require a Nightly Rust
 //!   compiler. This flag is now unused due to the [stabilization] of `NonNull`
 //!   in Rust 1.25.
+//! - `std` — Enables the use of the standard library. Enabled by default.
 //!
 //! [stabilization]: https://blog.rust-lang.org/2018/03/29/Rust-1.25.html
 //!
@@ -64,8 +65,6 @@ extern crate std;
 
 extern crate alloc;
 pub extern crate num;
-#[cfg(feature = "hashbrown")]
-pub extern crate hashbrown;
 extern crate unreachable;
 
 pub mod arena;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,6 @@
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::op_ref))]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(not(feature = "std"))]
 extern crate alloc;
 pub extern crate num;
 #[cfg(feature = "hashbrown")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,16 +61,22 @@
 
 pub extern crate num;
 extern crate unreachable;
+extern crate core;
+#[cfg(feature="alloc")]
+extern crate alloc;
 
+#[cfg(feature="alloc")]
 pub mod arena;
 pub mod bitmap;
 mod bitmaputils;
 pub mod int;
 pub mod ring;
+#[cfg(feature="alloc")]
 pub mod tlsf;
 
 pub use self::bitmap::{BitmapAlloc, BitmapAllocRegion};
 pub use self::ring::{Ring, RingRegion};
+#[cfg(feature="alloc")]
 pub use self::tlsf::{
     SafeTlsf, SafeTlsfRegion, SysTlsf, SysTlsfRegion, Tlsf, TlsfBlock, TlsfRegion,
 };

--- a/src/tlsf.rs
+++ b/src/tlsf.rs
@@ -99,14 +99,7 @@
 //! The allocation throughput is mostly equivalent to that of jemalloc.
 use core::fmt;
 
-#[cfg(not(feature = "std"))]
-use alloc::boxed::Box;
-#[cfg(not(feature = "std"))]
-use alloc::string::String;
-#[cfg(not(feature = "std"))]
-use alloc::vec;
-#[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
+use alloc::{boxed::Box, string::String, vec, vec::Vec};
 use num::{One, Zero};
 use unreachable::{unreachable, UncheckedOptionExt};
 

--- a/src/tlsf.rs
+++ b/src/tlsf.rs
@@ -97,7 +97,19 @@
 //! ## Performance
 //!
 //! The allocation throughput is mostly equivalent to that of jemalloc.
+#[cfg(not(feature = "std"))]
 use core::fmt;
+#[cfg(feature = "std")]
+use std::fmt;
+
+#[cfg(not(feature = "std"))]
+use alloc::boxed::Box;
+#[cfg(not(feature = "std"))]
+use alloc::string::String;
+#[cfg(not(feature = "std"))]
+use alloc::vec;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 use num::{One, Zero};
 use unreachable::{unreachable, UncheckedOptionExt};
 
@@ -524,7 +536,11 @@ where
         }
 
         let dump = || {
+            #[cfg(not(feature = "std"))]
             use core::fmt::Write;
+            #[cfg(feature = "std")]
+            use std::fmt::Write;
+
             let mut s = String::new();
             let mut cur_ptr = first_ptr.clone();
             loop {

--- a/src/tlsf.rs
+++ b/src/tlsf.rs
@@ -88,7 +88,7 @@
 //!
 //! ```
 //! use xalloc::tlsf::TlsfBlock;
-//! use std::mem::size_of;
+//! use core::mem::size_of;
 //! assert!(size_of::<TlsfBlock<u32, u32>>() >= 25);
 //! assert!(size_of::<TlsfBlock<u32, u64>>() >= 41);
 //! assert!(size_of::<TlsfBlock<u64, u64>>() >= 49);
@@ -98,7 +98,7 @@
 //!
 //! The allocation throughput is mostly equivalent to that of jemalloc.
 use num::{One, Zero};
-use std::fmt;
+use core::fmt;
 use unreachable::{unreachable, UncheckedOptionExt};
 
 use arena::{SafeArena, UnsafeArena, UnsafeArenaWithMembershipCheck};
@@ -524,7 +524,7 @@ where
         }
 
         let dump = || {
-            use std::fmt::Write;
+            use core::fmt::Write;
             let mut s = String::new();
             let mut cur_ptr = first_ptr.clone();
             loop {

--- a/src/tlsf.rs
+++ b/src/tlsf.rs
@@ -97,8 +97,8 @@
 //! ## Performance
 //!
 //! The allocation throughput is mostly equivalent to that of jemalloc.
-use num::{One, Zero};
 use core::fmt;
+use num::{One, Zero};
 use unreachable::{unreachable, UncheckedOptionExt};
 
 use arena::{SafeArena, UnsafeArena, UnsafeArenaWithMembershipCheck};

--- a/src/tlsf.rs
+++ b/src/tlsf.rs
@@ -97,10 +97,7 @@
 //! ## Performance
 //!
 //! The allocation throughput is mostly equivalent to that of jemalloc.
-#[cfg(not(feature = "std"))]
 use core::fmt;
-#[cfg(feature = "std")]
-use std::fmt;
 
 #[cfg(not(feature = "std"))]
 use alloc::boxed::Box;

--- a/src/tlsf.rs
+++ b/src/tlsf.rs
@@ -533,10 +533,7 @@ where
         }
 
         let dump = || {
-            #[cfg(not(feature = "std"))]
             use core::fmt::Write;
-            #[cfg(feature = "std")]
-            use std::fmt::Write;
 
             let mut s = String::new();
             let mut cur_ptr = first_ptr.clone();

--- a/src/tlsf.rs
+++ b/src/tlsf.rs
@@ -88,7 +88,7 @@
 //!
 //! ```
 //! use xalloc::tlsf::TlsfBlock;
-//! use core::mem::size_of;
+//! use std::mem::size_of;
 //! assert!(size_of::<TlsfBlock<u32, u32>>() >= 25);
 //! assert!(size_of::<TlsfBlock<u32, u64>>() >= 41);
 //! assert!(size_of::<TlsfBlock<u64, u64>>() >= 49);

--- a/tests/tlsf.rs
+++ b/tests/tlsf.rs
@@ -6,6 +6,7 @@
 // not be copied, modified,or distributed except
 // according to those terms.
 //
+#![cfg(feature = "std")]
 extern crate xalloc;
 
 use std::ops;


### PR DESCRIPTION
Fallbacks to use `core` and `alloc` in `no_std` environments